### PR TITLE
add "virtual file" to compiler for inline css, less or scss

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,5 @@
     "url": "https://github.com/marko-js/marko-loader/issues"
   },
   "homepage": "https://github.com/marko-js/marko-loader#readme",
-  "dependencies": {
-    "loader-utils": "^1.0.3"
-  }
+  "dependencies": {}
 }

--- a/src/code-loader.js
+++ b/src/code-loader.js
@@ -1,6 +1,0 @@
-var loaderUtils = require('loader-utils');
-
-module.exports = function() {
-    var query = loaderUtils.parseQuery(this.query);
-    return query.code.replace(/\/n/g, '\n');
-}

--- a/src/index.js
+++ b/src/index.js
@@ -1,76 +1,60 @@
 var markoCompiler = require('marko/compiler');
-var loaderUtils = require('loader-utils');
+// for way 1
+// var fs = 'fs'
 
-var defaultLoaders = {
-    'css':'style-loader!css-loader!'
+// for way 2
+var VirtualStats  = require('./virtual-stats');
+
+function patchPath(path) { //for windows platform
+  return path.replace(/\\/g, '\\\\');
 }
 
 module.exports = function(source) {
-    var query = loaderUtils.parseQuery(this.query);
-    var options = this.options;
-    var module = options && options.module;
-    var loaders = module && module.loaders || [];
-
-    this.cacheable(false);
-
-    if (query.target !== 'server' && markoCompiler.compileForBrowser) {
-        var compiled = markoCompiler.compileForBrowser(source, this.resourcePath, {
-    		writeToDisk: false
-    	});
-
-        var dependencies = compiled.dependencies.map((dependency, i) => {
-            if (!dependency.code) {
-                // external file, just require it
-                return `require('${dependency.path}');`
-            } else {
-                // inline content, we'll create a
-                var virtualPath = dependency.virtualPath;
-                var loader = getLoaderMatch(virtualPath, loaders);
-                var codeLoader = require.resolve('./code-loader');
-                var codeQuery = JSON.stringify({ code:dependency.code });
-                var loaderString = loaderUtils.stringifyRequest(this, `!!${loader}${codeLoader}?${codeQuery}!${this.resourcePath}`);
-                return `require(${loaderString})`;
-            }
-        })
-
-        return dependencies.concat(compiled.code).join('\n');
-    } else {
-        return markoCompiler.compile(source, this.resourcePath, {
-    		writeToDisk: false,
-            requireTemplates: true
-    	});
-    }
-};
-
-function getLoaderMatch(path, loaders) {
-    var loaderString;
-    var ext;
-
-    loaders.some(loader => {
-        if(loader.test.test(path)) {
-            loaderString = getLoaderString(loader.loader);
-            return true;
-        }
+  this.cacheable();
+  if (this.options.target === 'web') {
+    var compiled = markoCompiler.compileForBrowser(source, this.resourcePath, {
+      writeToDisk: false
     });
 
-    if (!loaderString) {
-        ext = path.slice(path.lastIndexOf('.')+1);
-        loaderString = getLoaderString(defaultLoaders[ext]);
-    }
+    var dependencies = compiled.dependencies.map((dependency, i) => {
+      if (dependency.code) {
+        //way 1: write file to dist, then require
+        //fs.writeFileSync(dependency.virtualPath, dependency.code, 'utf8')
 
-    return loaderString;
-}
-
-function getLoaderString(loader) {
-    if (!loader) {
+        //way 2: add virtual file to compiler, then require
+        var now = new Date().toString();
+        var options = {
+          dev: 8675309,
+          nlink: 1,
+          uid: 501,
+          gid: 20,
+          rdev: 0,
+          blksize: 4096,
+          ino: 44700000,
+          mode: 33188,
+          size: dependency.code.length,
+          atime: now,
+          mtime: now,
+          ctime: now,
+          birthtime: now,
+        };
+        this._compiler.inputFileSystem._statStorage.data[dependency.virtualPath] = [null, new VirtualStats(options)];
+        this._compiler.inputFileSystem._readFileStorage.data[dependency.virtualPath] = [null, dependency.code];
+        //add reuqire() in compiled file
+        var modulePath = patchPath(dependency.virtualPath);
+        return `require('${modulePath}');`;
+      } else if (dependency.type !== 'require') {
+        // external file, just require it
+        var modulePath = patchPath(dependency.path)
+        return `require('${modulePath}');`;
+      } else { //ignore self
         return '';
-    } else if (typeof loader === 'string') {
-        return loader.slice(-1) === '!' ? loader : loader + '!';
-    } else if (Array.isArray(loader)) {
-        return loader.map(getLoaderString).join('');
-    } else {
-        var options = loader.options;
-        var optionsString = options && (typeof options === 'string' ? options : JSON.stringify(options));
-        return loader.loader + (optionsString ? '?' + optionsString : '') + '!';
-    }
-}
+      }
+    });
+    return dependencies.concat(compiled.code).join('\n');
+  } else { //node and others
+    return markoCompiler.compile(source, this.resourcePath, {
+      writeToDisk: false
+    });
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -3,58 +3,60 @@ var markoCompiler = require('marko/compiler');
 // var fs = 'fs'
 
 // for way 2
-var VirtualStats  = require('./virtual-stats');
+var VirtualStats = require('./virtual-stats');
 
 function patchPath(path) { //for windows platform
-  return path.replace(/\\/g, '\\\\');
+    return path.replace(/\\/g, '\\\\');
 }
 
 module.exports = function(source) {
-  this.cacheable();
-  if (this.options.target === 'web') {
-    var compiled = markoCompiler.compileForBrowser(source, this.resourcePath, {
-      writeToDisk: false
-    });
+    this.cacheable();
+    if (this.options.target === 'web') {
+        var compiled = markoCompiler.compileForBrowser(source, this.resourcePath, {
+            writeToDisk: false
+        });
 
-    var dependencies = compiled.dependencies.map((dependency, i) => {
-      if (dependency.code) {
-        //way 1: write file to dist, then require
-        //fs.writeFileSync(dependency.virtualPath, dependency.code, 'utf8')
+        var dependencies = compiled.dependencies.map((dependency, i) => {
+            if (dependency.code) {
+                //way 1: write file to dist, then require
+                //fs.writeFileSync(dependency.virtualPath, dependency.code, 'utf8')
 
-        //way 2: add virtual file to compiler, then require
-        var now = new Date().toString();
-        var options = {
-          dev: 8675309,
-          nlink: 1,
-          uid: 501,
-          gid: 20,
-          rdev: 0,
-          blksize: 4096,
-          ino: 44700000,
-          mode: 33188,
-          size: dependency.code.length,
-          atime: now,
-          mtime: now,
-          ctime: now,
-          birthtime: now,
-        };
-        this._compiler.inputFileSystem._statStorage.data[dependency.virtualPath] = [null, new VirtualStats(options)];
-        this._compiler.inputFileSystem._readFileStorage.data[dependency.virtualPath] = [null, dependency.code];
-        //add reuqire() in compiled file
-        var modulePath = patchPath(dependency.virtualPath);
-        return `require('${modulePath}');`;
-      } else if (dependency.type !== 'require') {
-        // external file, just require it
-        var modulePath = patchPath(dependency.path)
-        return `require('${modulePath}');`;
-      } else { //ignore self
-        return '';
-      }
-    });
-    return dependencies.concat(compiled.code).join('\n');
-  } else { //node and others
-    return markoCompiler.compile(source, this.resourcePath, {
-      writeToDisk: false
-    });
-  }
+                //way 2: add virtual file to compiler, then require
+                var now = new Date().toString();
+                var options = {
+                    dev: 8675309,
+                    nlink: 1,
+                    uid: 501,
+                    gid: 20,
+                    rdev: 0,
+                    blksize: 4096,
+                    ino: 44700000,
+                    mode: 33188,
+                    size: dependency.code.length,
+                    atime: now,
+                    mtime: now,
+                    ctime: now,
+                    birthtime: now,
+                };
+                if (this._compiler) {
+                    this._compiler.inputFileSystem._statStorage.data[dependency.virtualPath] = [null, new VirtualStats(options)];
+                    this._compiler.inputFileSystem._readFileStorage.data[dependency.virtualPath] = [null, dependency.code];
+                }
+                //add reuqire() in compiled file
+                var modulePath = patchPath(dependency.virtualPath);
+                return `require('${modulePath}');`;
+            } else if (dependency.type !== 'require') {
+                // external file, just require it
+                var modulePath = patchPath(dependency.path)
+                return `require('${modulePath}');`;
+            } else { //ignore self
+                return '';
+            }
+        });
+        return dependencies.concat(compiled.code).join('\n');
+    } else { //node and others
+        return markoCompiler.compile(source, this.resourcePath, {
+            writeToDisk: false
+        });
+    }
 };

--- a/src/virtual-stats.js
+++ b/src/virtual-stats.js
@@ -1,0 +1,96 @@
+/**
+ * Used to cache a stats object for the virtual file.
+ * Extracted from the `mock-fs` package.
+ *
+ * @author Tim Schaub http://tschaub.net/
+ * @link https://github.com/tschaub/mock-fs/blob/master/lib/binding.js
+ * @link https://github.com/tschaub/mock-fs/blob/master/license.md
+ */
+
+/* eslint-disable no-restricted-syntax, no-prototype-builtins, no-continue */
+/* eslint-disable no-bitwise, no-underscore-dangle */
+
+var constants = require('constants');
+
+class VirtualStats {
+  /**
+   * Create a new stats object.
+   * @param {Object} config Stats properties.
+   * @constructor
+   */
+  constructor(config) {
+    for (const key in config) {
+      if (!config.hasOwnProperty(key)) {
+        continue;
+      }
+      this[key] = config[key];
+    }
+  }
+
+  /**
+   * Check if mode indicates property.
+   * @param {number} property Property to check.
+   * @return {boolean} Property matches mode.
+   */
+  _checkModeProperty(property) {
+    return ((this.mode & constants.S_IFMT) === property);
+  }
+
+
+  /**
+   * @return {Boolean} Is a directory.
+   */
+  isDirectory() {
+    return this._checkModeProperty(constants.S_IFDIR);
+  }
+
+
+  /**
+   * @return {Boolean} Is a regular file.
+   */
+  isFile() {
+    return this._checkModeProperty(constants.S_IFREG);
+  }
+
+
+  /**
+   * @return {Boolean} Is a block device.
+   */
+  isBlockDevice() {
+    return this._checkModeProperty(constants.S_IFBLK);
+  }
+
+
+  /**
+   * @return {Boolean} Is a character device.
+   */
+  isCharacterDevice() {
+    return this._checkModeProperty(constants.S_IFCHR);
+  }
+
+
+  /**
+   * @return {Boolean} Is a symbolic link.
+   */
+  isSymbolicLink() {
+    return this._checkModeProperty(constants.S_IFLNK);
+  }
+
+
+  /**
+   * @return {Boolean} Is a named pipe.
+   */
+  isFIFO() {
+    return this._checkModeProperty(constants.S_IFIFO);
+  }
+
+
+  /**
+   * @return {Boolean} Is a socket.
+   */
+  isSocket() {
+    return this._checkModeProperty(constants.S_IFSOCK);
+  }
+}
+
+module.exports = VirtualStats;


### PR DESCRIPTION
Change List:
1. After complied by marko，create "virtual file" in webpack compiler.
2. Use "this.loader.options.target" for identify platform

Benefits:
1. "virtual file" looks like a normal file by webpack, so other loader(such as sass-loader) can process them in normal way. 
2. SourceMap support friendly.
  