### PR TITLE
Add Webpack 2 config syntax support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,10 @@ var defaultLoaders = {
 }
 
 module.exports = function(source) {
-    var query = loaderUtils.parseQuery(this.query);
+    var query = this.query && loaderUtils.parseQuery(this.query) || {};
     var options = this.options;
     var module = options && options.module;
-    var loaders = module && module.loaders || [];
+    var loaders = module && (module.rules || []).concat(module.loaders || []);
 
     this.cacheable(false);
 
@@ -48,7 +48,7 @@ function getLoaderMatch(path, loaders) {
 
     loaders.some(loader => {
         if(loader.test.test(path)) {
-            loaderString = getLoaderString(loader.loader);
+            loaderString = getLoaderString(loader.use || loader.loader);
             return true;
         }
     });


### PR DESCRIPTION
Hi Guys,

I have tried to submit minimal change set to add support for Webpack 2 config syntax. With these changes both Webpack 1 syntax and Webpack 2 syntax should be supported. I have tested this on vanilla `marko-webpack` example and `marko-webpack` example upgraded to Webpack 2 syntax.