### PR TITLE
Automatically detect webpack target

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Install required packages:
 
 ```bash
 npm install marko --save
-npm install marko-loader --save
+npm install marko-loader --save-dev
 ```
 
 And then register the marko loader in your webpack configuration file:
@@ -47,6 +47,11 @@ _./index.js:_
 var template = require('./template.marko')
 var html = template.renderToString({ name: 'Frank' });
 ```
+
+# Compilation target
+
+`marko-loader` will automatically detect your webpack target and output the appropriately compiled Marko code.
+If you wish to override this behaviour simply add the `target` field in the options for this loader.
 
 # Additional resources
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ var codeLoader = require.resolve('./code-loader');
 
 module.exports = function(source) {
     const queryOptions = loaderUtils.getOptions(this);  // Not the same as this.options
-    const target = queryOptions && queryOptions.target;
+    const target = normalizeTarget((queryOptions && queryOptions.target) || this.target);
 
     const module = this.options.module;
     const loaders = module && (module.loaders || module.rules) || [];
@@ -77,5 +77,19 @@ function getLoaderString(loader) {
         var options = loader.options;
         var optionsString = options && (typeof options === 'string' ? options : JSON.stringify(options));
         return loader.loader + (optionsString ? '?' + optionsString : '') + '!';
+    }
+}
+
+function normalizeTarget (target) {
+    switch (target) {
+      case 'server':
+      case 'node':
+      case 'async-node':
+      case 'atom':
+      case 'electron':
+      case 'electron-main':
+        return 'server';
+      default:
+        return 'browser';
     }
 }


### PR DESCRIPTION
Currently users must specify `target: 'server'` for server builds. This PR makes it so that if this option is not specified it will infer the compilation target based off or webpacks compilation target.

---

This also resolves https://github.com/marko-js/marko-loader/issues/18 since it [normalizes browser and server names](https://github.com/marko-js/marko-loader/pull/19/files#diff-1fdf421c05c1140f6d71444ea2b27638R83).