### PR TITLE
Webpack 3 / 4 compatibility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports = function(source) {
     const queryOptions = loaderUtils.getOptions(this);  // Not the same as this.options
     const target = normalizeTarget((queryOptions && queryOptions.target) || this.target);
 
-    const module = this.options.module;
+    const module = this.options ? this.options.module : this.query;
     const loaders = module && (module.loaders || module.rules) || [];
 
     this.cacheable(false);


### PR DESCRIPTION
Webpack 3 already deprecated `this.options` in the loader context. Webpack 4 removes it now. Loaders should receive all options via this.query.