### PR TITLE
support webpack 4 loader api

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports = function(source) {
     const queryOptions = loaderUtils.getOptions(this);  // Not the same as this.options
     const target = normalizeTarget((queryOptions && queryOptions.target) || this.target);
 
-    const module = this.options.module;
+    const module = this.options ? this.options.module : this._compilation.options.module;
     const loaders = module && (module.loaders || module.rules) || [];
 
     this.cacheable(false);


### PR DESCRIPTION
Webpack 4 loader api removes the deprecated `this.options`  however the same options is available under `this._compilation.options`